### PR TITLE
Upgrade to bindings 0.6.0 and SDK 0.12.20

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,9 @@ target/
 logs/
 *.log
 template-ids.json
+.package-database
+daml/PingPong.hi
+dist
+.idea
+.*.swp
+.interfaces

--- a/README.md
+++ b/README.md
@@ -3,17 +3,19 @@
 ## Table of contents
 
 1.  [Introduction](#introduction)
-2.  [Create the project](#create-the-project)
-3.  [Run the sandbox](#run-the-sandbox)
-4.  [Run the skeleton app](#run-the-skeleton-app)
-5.  [Understand the skelelon](#understand-the-skeleton)
-6.  [Retrieve the package identifiers](#retrieve-the-package-identifiers)
-7.  [Understand the `PingPong` module](#understand-the-pingpong-module)
-8.  [Pass the parties as parameters](#pass-the-parties-as-parameters)
-9.  [Create a contract](#create-a-contract)
-10. [Read the transactions](#read-the-transactions)
-11. [Exercise a choice](#exercise-a-choice)
-12. [Read the active contracts](#read-the-active-contracts)
+2.  [Prerequisites](#prerequisites)
+3.  [Create the project](#create-the-project)
+4.  [Compile the DAML Code](#compile-the-daml-code)
+5.  [Run the sandbox](#run-the-sandbox)
+6.  [Run the skeleton app](#run-the-skeleton-app)
+7.  [Understand the skelelon](#understand-the-skeleton)
+8.  [Retrieve the package identifiers](#retrieve-the-package-identifiers)
+9.  [Understand the `PingPong` module](#understand-the-pingpong-module)
+10. [Pass the parties as parameters](#pass-the-parties-as-parameters)
+11. [Create a contract](#create-a-contract)
+12. [Read the transactions](#read-the-transactions)
+13. [Exercise a choice](#exercise-a-choice)
+14. [Read the active contracts](#read-the-active-contracts)
 
 ## Introduction
 
@@ -27,6 +29,14 @@ The focus is not on the complexity of the model, but rather on how to use the bi
 
 [Back to the table of contents](#table-of-contents)
 
+## Prerequisites
+
+The DAML code in this repository makes use of the SDK 0.12.20 and the `daml` SDK assistant.
+
+You are therefore strongly advised to have at least the SDK 0.12.20 installed.
+
+[Back to the table of contents](#table-of-contents)
+
 ## Create the project
 
 There is a skeleton application called `ex-tutorial-nodejs` that you can get from the [GitHub](https://github.com/digital-asset/ex-tutorial-nodejs).
@@ -35,9 +45,17 @@ To set it up, clone the repo, making sure to checkout the tag corresponding to t
 
     git clone git@github.com:digital-asset/ex-tutorial-nodejs.git
     cd ex-tutorial-nodejs
-    git checkout 0.5.0
+    git checkout v0.6.0
 
 The repo includes `daml/PingPong.daml`, which is the source for a DAML module with two templates: `Ping` and `Pong`. The app uses these.
+
+[Back to the table of contents](#table-of-contents)
+
+## Compile the DAML code
+
+Before getting started, build the DAML code with
+
+    daml build
 
 [Back to the table of contents](#table-of-contents)
 
@@ -45,11 +63,12 @@ The repo includes `daml/PingPong.daml`, which is the source for a DAML module wi
 
 Use the sandbox to run and test your application.
 
-Now that you created the project and you're in its directory, start the sandbox by running:
+Now that you created the project and you're in its directory:
 
-    da sandbox
+1. open a new shell (the running sandbox will keep it busy), and
+2. start the sandbox by running
 
-Starting the sandbox automatically compiles `PingPong.daml` and loads it.
+       daml sandbox dist/ex-tutorial-nodejs.dar
 
 [Back to the table of contents](#table-of-contents)
 
@@ -59,15 +78,15 @@ You are now set to write your own application. The template includes a skeleton 
 
 1. Install the dependencies for your package (including the bindings):
 
-    npm install
+       npm install
 
 2. Start the application:
 
-    npm start
+       npm start
 
 3. Verify the output is correct
 
-    hello from <LEDGER_ID>
+       hello from <LEDGER_ID>
 
 [Back to the table of contents](#table-of-contents)
 
@@ -77,24 +96,28 @@ The code for the script you just ran is `index.js`.
 
 Let's go through the skeleton part by part to understand what's going on:
 
-    const daml = require('@da/daml-ledger');
+    const ledger = require('@digital-asset/daml-ledger');
+
+    const daml = ledger.daml;
 
     const uuidv4 = require('uuid/v4');
 
 The first line loads the bindings and allows you to refer to them through the `daml` object.
 
-The second one introduces a dependency that is going to be later used to generate unique identifiers; no need to worry about it now.
+The second one creates a shorthand for the `daml` object in the `daml-ledger` library, that can be used to express DAML values in your code concisely.
+
+The third one introduces a dependency that is going to be later used to generate unique identifiers; no need to worry about it now.
 
     let [, , host, port] = process.argv;
 
     host = host || 'localhost';
-    port = port || 7600;
+    port = port || 6865;
 
 These lines read the command-line arguments and provide some sensible defaults.
 
 Now to the juicy part:
 
-    daml.DamlLedgerClient.connect({ host: host, port: port }, (error, client) => {
+    ledger.DamlLedgerClient.connect({ host: host, port: port }, (error, client) => {
         if (error) throw error;
         console.log('hello from', client.ledgerId);
     });
@@ -134,17 +157,17 @@ It's time to write some code to verify that you're good to go. Open the `index.j
 
 First of all, right after the first `require` statement, add a new one to load the `template-ids.json` file that has just been created.
 
-    const daml = require('@digitalasset/daml-ledger');
+    const ledger = require('@digitalasset/daml-ledger');
     const templateIds = require('./template-ids.json');
 
 Right beneath that line, initialize two constants to hold the `Ping` and `Pong` template identifiers:
 
-    const PING = templateIds['PingPong.Ping'];
-    const PONG = templateIds['PingPong.Pong'];
+    const PING = templateIds['PingPong:Ping'];
+    const PONG = templateIds['PingPong:Pong'];
 
 Finally print the template identifiers:
 
-    daml.DamlLedgerClient.connect({ host: host, port: port }, (error, client) => {
+    ledger.DamlLedgerClient.connect({ host: host, port: port }, (error, client) => {
         if (error) throw error;
         console.log('hello from', client.ledgerId);
         console.log('Ping', PING);
@@ -189,7 +212,7 @@ Read those from the command line by editing the part where the arguments are rea
 
     let [, , sender, receiver, host, port] = process.argv;
     host = host || 'localhost';
-    port = port || 7600;
+    port = port || 6865;
     if (!sender || !receiver) {
         console.log('Missing sender and/or receiver arguments, exiting.');
         process.exit(-1);
@@ -226,9 +249,9 @@ First of all, the following is the `request` for the `CommandService`. Have a lo
                 templateId: PING,
                 arguments: {
                     fields: {
-                        sender: { valueType: 'party', party: sender },
-                        receiver: { valueType: 'party', party: receiver },
-                        count: { valueType: 'int64', int64: '0' }
+                        sender: daml.party(sender),
+                        receiver: daml.party(receiver),
+                        count: daml.int64(0)
                     }
                 }
             }]
@@ -264,7 +287,7 @@ This is already a sizeable chunk of code that performs a clearly defined task. W
 
 The code should now look like the following:
 
-    daml.DamlLedgerClient.connect({ host: host, port: port }, (error, client) => {
+    ledger.DamlLedgerClient.connect({ host: host, port: port }, (error, client) => {
         if (error) throw error;
 
         createFirstPing();
@@ -283,9 +306,9 @@ The code should now look like the following:
                         templateId: PING,
                         arguments: {
                             fields: {
-                                sender: { valueType: 'party', party: sender },
-                                receiver: { valueType: 'party', party: receiver },
-                                count: { valueType: 'int64', int64: '0' }
+                                sender: daml.party(sender),
+                                receiver: daml.party(receiver),
+                                count: daml.int64(0)
                             }
                         }
                     }]
@@ -322,7 +345,7 @@ This method takes the following request:
     const filtersByParty = {};
     filtersByParty[sender] = { inclusive: { templateIds: [PING, PONG] } };
     const request = {
-        begin: { boundary: da.LedgerOffset.Boundary.END },
+        begin: { boundary: ledger.LedgerOffsetBoundaryValue.BEGIN },
         filter: { filtersByParty: filtersByParty }
     };
 
@@ -365,7 +388,7 @@ Wrap this code in a new function called `listenForTransactions`, place it within
 
 When you are done, your code should look like the following:
 
-    daml.DamlLedgerClient.connect({ host: host, port: port }, (error, client) => {
+    ledger.DamlLedgerClient.connect({ host: host, port: port }, (error, client) => {
         if (error) throw error;
 
         listenForTransactions();
@@ -385,9 +408,9 @@ When you are done, your code should look like the following:
                         templateId: PING,
                         arguments: {
                             fields: {
-                                sender: { valueType: 'party', party: sender },
-                                receiver: { valueType: 'party', party: receiver },
-                                count: { valueType: 'int64', int64: '0' }
+                                sender: daml.party(sender),
+                                receiver: daml.party(receiver),
+                                count: daml.int64(0)
                             }
                         }
                     }]
@@ -404,7 +427,7 @@ When you are done, your code should look like the following:
             const filtersByParty = {};
             filtersByParty[sender] = { inclusive: { templateIds: [PING, PONG] } };
             const request = {
-                begin: { offsetType: 'boundary', boundary: daml.LedgerOffsetBoundaryValue.END },
+                begin: { offsetType: 'boundary', boundary: ledger.LedgerOffsetBoundaryValue.BEGIN },
                 filter: { filtersByParty: filtersByParty }
             };
             const transactions = client.transactionClient.getTransactions(request);
@@ -476,7 +499,7 @@ The following snippet of code does precisely this.
                 templateId: templateId,
                 contractId: contractId,
                 choice: reaction,
-                argument: { valueType: 'record', fields: {} }
+                argument: daml.record({})
             });
         }
     }
@@ -509,9 +532,11 @@ Wrap this code into a new function `react` that takes a `workflowId` and an `eve
 
 Finally, pass the `react` function as a parameter to the only call of `listenForTransactions`.
 
+The app is almost ready to start, there's only one tweak to make: before writing the code to react to transactions, in order for us to observe the transactions while running a single application, the code you wrote subscribed to the ledger from it's beginning (`LedgerOffsetBoundaryValue.BEGIN`). The next time you'll run the application you'll instead _tail_ the ledger subscribing to the end of if (`LedgerOffsetBoundaryValue.END`) so that you can only observe the live interaction between two running applications.
+
 Your code should now look like the following:
 
-    daml.DamlLedgerClient.connect({ host: host, port: port }, (error, client) => {
+    ledger.DamlLedgerClient.connect({ host: host, port: port }, (error, client) => {
         if (error) throw error;
 
         listenForTransactions(react);
@@ -531,9 +556,9 @@ Your code should now look like the following:
                         templateId: PING,
                         arguments: {
                             fields: {
-                                sender: { valueType: 'party', party: sender },
-                                receiver: { valueType: 'party', party: receiver },
-                                count: { valueType: 'int64', int64: '0' }
+                                sender: daml.party(sender),
+                                receiver: daml.party(receiver),
+                                count: daml.int64(0)
                             }
                         }
                     }]
@@ -550,7 +575,7 @@ Your code should now look like the following:
             const filtersByParty = {};
             filtersByParty[sender] = { inclusive: { templateIds: [PING, PONG] } };
             const request = {
-                begin: { offsetType: 'boundary', boundary: daml.LedgerOffsetBoundaryValue.END },
+                begin: { offsetType: 'boundary', boundary: ledger.LedgerOffsetBoundaryValue.END },
                 filter: { filtersByParty: filtersByParty }
             };
             const transactions = client.transactionClient.getTransactions(request);
@@ -588,7 +613,7 @@ Your code should now look like the following:
                         templateId: templateId,
                         contractId: contractId,
                         choice: reaction,
-                        argument: { valueType: 'record', fields: {} }
+                        argument: daml.record({})
                     });
                 }
             }
@@ -694,23 +719,25 @@ In this new example the application first processes the current active contracts
 
 Note that the transaction filter was factored out as it can be shared. The final code would look like this:
 
-    const daml = require('@digitalasset/daml-ledger');
+    const ledger = require('@digitalasset/daml-ledger');
     const templateIds = require('./template-ids.json');
 
-    const PING = templateIds['PingPong.Ping'];
-    const PONG = templateIds['PingPong.Pong'];
+    const PING = templateIds['PingPong:Ping'];
+    const PONG = templateIds['PingPong:Pong'];
+
+    const daml = ledger.daml;
 
     const uuidv4 = require('uuid/v4');
 
     let [, , sender, receiver, host, port] = process.argv;
     host = host || 'localhost';
-    port = port || 7600;
+    port = port || 6865;
     if (!sender || !receiver) {
         console.log('Missing sender and/or receiver arguments, exiting.');
         process.exit(-1);
     }
 
-    daml.DamlLedgerClient.connect({ host: host, port: port }, (error, client) => {
+    ledger.DamlLedgerClient.connect({ host: host, port: port }, (error, client) => {
         if (error) throw error;
 
         const filtersByParty = {};
@@ -736,9 +763,9 @@ Note that the transaction filter was factored out as it can be shared. The final
                         templateId: PING,
                         arguments: {
                             fields: {
-                                sender: { valueType: 'party', party: sender },
-                                receiver: { valueType: 'party', party: receiver },
-                                count: { valueType: 'int64', int64: '0' }
+                                sender: daml.party(sender),
+                                receiver: daml.party(receiver),
+                                count: daml.int64(0)
                             }
                         }
                     }]
@@ -753,7 +780,7 @@ Note that the transaction filter was factored out as it can be shared. The final
         function listenForTransactions(offset, transactionFilter, callback) {
             console.log(`${sender} starts reading transactions from offset: ${offset}.`);
             const request = {
-                begin: { offsetType: 'boundary', boundary: daml.LedgerOffsetBoundaryValue.END },
+                begin: { offsetType: 'boundary', boundary: ledger.LedgerOffsetBoundaryValue.END },
                 filter: transactionFilter
             };
             const transactions = client.transactionClient.getTransactions(request);
@@ -845,10 +872,13 @@ Note that the transaction filter was factored out as it can be shared. The final
 
     });
 
-Before running this you should start with a clean ledger to avoid being confused by the unprocessed contracts from previous examples.
+Before running this you should start with a clean ledger to avoid being confused by the unprocessed contracts from previous examples:
 
-    da stop
-    da sandbox
+1. go to the shell where you are running the sandbox
+2. hit CTRL+C to shut it down and wait for your shell prompt
+3. restart the sandbox
+
+       daml sandbox dist/ex-tutorial-nodejs.dar
 
 Then run:
 
@@ -879,3 +909,5 @@ You should see the following outputs respectively:
     Bob (workflow Ping-Bob): Ping at count 3
 
 Alice joining an empty ledger has no active contracts to process. Bob however, who joins later, will see Alice's `Ping` contract and process it. Afterwards he will continue listening to transactions from offset 1.
+
+[Back to the table of contents](#table-of-contents)

--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ The repo includes `daml/PingPong.daml`, which is the source for a DAML module wi
 
 ## Compile the DAML code
 
-Before getting started, build the DAML code with
+Before getting started, move to the project root directory and build the DAML code with
 
     daml build
 
@@ -61,9 +61,7 @@ Before getting started, build the DAML code with
 
 ## Run the sandbox
 
-Use the sandbox to run and test your application.
-
-Now that you created the project and you're in its directory:
+Use the sandbox to run and test your application:
 
 1. open a new shell (the running sandbox will keep it busy), and
 2. start the sandbox by running

--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ The focus is not on the complexity of the model, but rather on how to use the bi
 
 The DAML code in this repository makes use of the SDK 0.12.20 and the `daml` SDK assistant.
 
-You are therefore strongly advised to have at least the SDK 0.12.20 installed.
+Make sure you have the SDK 0.12.20 (or greater) installed.
 
 [Back to the table of contents](#table-of-contents)
 

--- a/README.md
+++ b/README.md
@@ -218,7 +218,9 @@ Read those from the command line by editing the part where the arguments are rea
 
 Try to run it without arguments (or with just one) to see the error popping up.
 
-Try to run it with both arguments to see the application working just as it did before.
+Try to run it with both arguments to see the application working just as it did before, as follows:
+
+    npm start Alice Bob
 
 [Back to the table of contents](#table-of-contents)
 

--- a/README.md
+++ b/README.md
@@ -359,7 +359,7 @@ Have a look at the request:
 
 #### Why subscribing from the beginning and not simply _tailing_ the transactions?
 
-Purely for educational purposes: in the end, the application will _tail_ the transaction stream. For now, we'll subscribe from the beginning to make sure the application can read its own transaction, so that you can more easily observe the behavior of creating a contract and observing that same event.
+Purely for educational purposes: in the end, the application will _tail_ the transaction stream. For now, the app subscribes from the beginning to make sure it can read the events it causes, so that you can more easily observe the contract creation.
 
 ---
 
@@ -540,7 +540,7 @@ Wrap this code into a new function `react` that takes a `workflowId` and an `eve
 
 Finally, pass the `react` function as a parameter to the only call of `listenForTransactions`.
 
-The application is now ready to be tested with two instances running at once: we can now _tail_ the transaction stream instead of subscribing to it from the beginning by replacing the occurrences of `ledger.LedgerOffsetBoundaryValue.BEGIN` with `ledger.LedgerOffsetBoundaryValue.END`.
+The application is now ready to be tested with two instances running at once: it can now _tail_ the transaction stream instead of subscribing to it from the beginning by replacing the occurrences of `ledger.LedgerOffsetBoundaryValue.BEGIN` with `ledger.LedgerOffsetBoundaryValue.END`.
 
 Review the code before running the application. Your code should now look like the following:
 

--- a/README.md
+++ b/README.md
@@ -100,7 +100,7 @@ Let's go through the skeleton part by part to understand what's going on:
 
     const uuidv4 = require('uuid/v4');
 
-The first line loads the bindings and allows you to refer to them through the `daml` object.
+The first line loads the bindings and allows you to refer to them through the `ledger` object.
 
 The second one creates a shorthand for the `daml` object in the `daml-ledger` library, that can be used to express DAML values in your code concisely.
 

--- a/README.md
+++ b/README.md
@@ -870,7 +870,7 @@ Note that the transaction filter was factored out as it can be shared. The final
 
     });
 
-Before running this you should start with a clean ledger to avoid being confused by the unprocessed contracts from previous examples:
+Before running the application, start with a clean ledger to avoid receiving unprocessed contracts from previous examples:
 
 1. go to the shell where you are running the sandbox
 2. hit CTRL+C to shut it down and wait for your shell prompt

--- a/README.md
+++ b/README.md
@@ -102,9 +102,9 @@ Let's go through the skeleton part by part to understand what's going on:
 
 The first line loads the bindings and allows you to refer to them through the `ledger` object.
 
-The second one creates a shorthand for the `daml` object in the `daml-ledger` library, that can be used to express DAML values in your code concisely.
+The second line creates a shorthand for the `daml` object in the `daml-ledger` library, that can be used to express DAML values in your code concisely.
 
-The third one introduces a dependency that is going to be later used to generate unique identifiers; no need to worry about it now.
+The third line introduces a dependency that is going to be later used to generate unique identifiers; no need to worry about it now.
 
     let [, , host, port] = process.argv;
 

--- a/README.md
+++ b/README.md
@@ -469,10 +469,31 @@ You should see an output like the following:
 
     Alice starts reading transactions.
     Created Ping contract from Alice to Bob.
+    Transaction read: 0
     Transaction read: 1
 
+Note that the exact number of transactions read depends on whether you have already ran the application and created contracts more then once.
+
 Your application is now able to create contracts and listen to transactions on the ledger. Very good!
+
 You can now hit CTRL-C to quit the application.
+
+---
+
+### Note
+
+#### Start from a clean slate
+
+It's not a requirement for this tutorial, but if you want to reset the sandbox to its initial state, do the following:
+
+1. Go to the console where the sandbox is running
+2. Hit CTRL+C to stop it
+3. Run it again as you did before
+
+       daml sandbox dist/ex-tutorial-nodejs.dar
+
+---
+
 
 [Back to the table of contents](#table-of-contents)
 

--- a/README.md
+++ b/README.md
@@ -349,11 +349,21 @@ This method takes the following request:
 
 Have a look at the request:
 
-- `begin`: the offset at which you'll start reading transactions from the ledger. In this case you want to listen starting from the latest one (represented by the constant `da.LedgerOffset.Boundary.END`)
+- `begin`: the offset at which you'll start reading transactions from the ledger. In this case you want to listen starting from the first one (represented by the constant `daml.LedgerOffsetBoundaryValue.BEGIN`)
 - `end`: the optional offset at which you want the reads to end -- if absent (as in this case) the application keeps listening to incoming transactions
 - `filter`: represents which contracts you want the ledger to show you: in this case you are asking for the transactions visible to `sender` containing contracts whose `templateId` matches either `PING` or `PONG`.
 
-When the `getTransactions` method is invoked with this request the application listens to the latest transactions coming to the ledger.
+---
+
+### Note
+
+#### Why subscribing from the beginning and not simply _tailing_ the transactions?
+
+Purely for educational purposes: in the end, the application will _tail_ the transaction stream. For now, we'll subscribe from the beginning to make sure the application can read its own transaction, so that you can more easily observe the behavior of creating a contract and observing that same event.
+
+---
+
+When the `getTransactions` method is invoked with this request the application listens to all transactions coming to the ledger.
 
 The output of this method is a Node.js stream. As such, you can register callbacks on the `'data'` and `'error'` events.
 
@@ -530,9 +540,9 @@ Wrap this code into a new function `react` that takes a `workflowId` and an `eve
 
 Finally, pass the `react` function as a parameter to the only call of `listenForTransactions`.
 
-The app is almost ready to start, there's only one tweak to make: before writing the code to react to transactions, in order for us to observe the transactions while running a single application, the code you wrote subscribed to the ledger from it's beginning (`LedgerOffsetBoundaryValue.BEGIN`). The next time you'll run the application you'll instead _tail_ the ledger subscribing to the end of if (`LedgerOffsetBoundaryValue.END`) so that you can only observe the live interaction between two running applications.
+The application is now ready to be tested with two instances running at once: we can now _tail_ the transaction stream instead of subscribing to it from the beginning by replacing the occurrences of `ledger.LedgerOffsetBoundaryValue.BEGIN` with `ledger.LedgerOffsetBoundaryValue.END`.
 
-Your code should now look like the following:
+Review the code before running the application. Your code should now look like the following:
 
     ledger.DamlLedgerClient.connect({ host: host, port: port }, (error, client) => {
         if (error) throw error;

--- a/da.yaml
+++ b/da.yaml
@@ -1,8 +1,0 @@
-project:
-  sdk-version: 0.12.2
-  name: ex-tutorial-nodejs
-  source: daml/PingPong.daml
-  parties:
-  - Alice
-  - Bob
-version: 2

--- a/daml.yaml
+++ b/daml.yaml
@@ -1,0 +1,12 @@
+sdk-version: 0.12.20
+name: ex-tutorial-nodejs
+source: daml/PingPong.daml
+parties:
+- Alice
+- Bob
+exposed-modules:
+- PingPong
+version: '0.6.0'
+dependencies:
+- daml-prim
+- daml-stdlib

--- a/index.js
+++ b/index.js
@@ -1,15 +1,17 @@
 // Copyright (c) 2019, Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-const daml = require('@digitalasset/daml-ledger');
+const ledger = require('@digitalasset/daml-ledger');
+
+const daml = ledger.daml;
 
 const uuidv4 = require('uuid/v4');
 
 let [, , host, port] = process.argv;
 host = host || 'localhost';
-port = port || 7600;
+port = port || 6865;
 
-daml.DamlLedgerClient.connect({ host: host, port: port }, (error, client) => {
+ledger.DamlLedgerClient.connect({ host: host, port: port }, (error, client) => {
     if (error) throw error;
     console.log('hello from', client.ledgerId);
 });

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,13 +1,13 @@
 {
-  "name": "tutorial",
-  "version": "0.5.0",
+  "name": "ex-tutorial-nodejs",
+  "version": "0.6.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
     "@digitalasset/daml-ledger": {
-      "version": "0.5.0",
-      "resolved": "https://registry.npmjs.org/@digitalasset/daml-ledger/-/daml-ledger-0.5.0.tgz",
-      "integrity": "sha512-ar6yyW4s/EMu/7fHbO4A64YNpHNPto4AXYE7yLb3fYRNp6bmGNj6s+TyQh4Mc2fzThFs8RZOpawuQclPjEUm5A==",
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/@digitalasset/daml-ledger/-/daml-ledger-0.6.0.tgz",
+      "integrity": "sha512-o/kMewdBeCKM5zU8+EiECwP7/2OE7uATceH3UwI4S+I6HhTKK1CEtnNYgPpepYmqvO51ZJkcPDR/zhjregg+qA==",
       "requires": {
         "google-protobuf": "3.7.1",
         "grpc": "1.18.0"
@@ -90,9 +90,9 @@
       "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8="
     },
     "glob": {
-      "version": "7.1.3",
-      "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.3.tgz",
-      "integrity": "sha512-vcfuiIxogLV4DlGBHIUOwI0IbrJ8HWPc4MU7HzviGeNho/UJDfi6B5p3sHeWIQ0KGIU0Jpxi5ZHxemQfLkkAwQ==",
+      "version": "7.1.4",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.4.tgz",
+      "integrity": "sha512-hkLPepehmnKk41pUGm3sYxoFs/umurYfYJCerbXEyFIWcAzvpipAgVkBqqT9RBKMGjnq6kMuyYwha6csxbiM1A==",
       "requires": {
         "fs.realpath": "^1.0.0",
         "inflight": "^1.0.4",
@@ -583,9 +583,9 @@
       }
     },
     "nan": {
-      "version": "2.13.2",
-      "resolved": "https://registry.npmjs.org/nan/-/nan-2.13.2.tgz",
-      "integrity": "sha512-TghvYc72wlMGMVMluVo9WRJc0mB8KxxF/gZ4YYFy7V2ZQX9l7rgbPg7vjS9mt6U5HXODVFVI2bOduCzwOMv/lw=="
+      "version": "2.14.0",
+      "resolved": "https://registry.npmjs.org/nan/-/nan-2.14.0.tgz",
+      "integrity": "sha512-INOFj37C7k3AfaNTtX8RhsTw7qRy7eLET14cROi9+5HAVbbHuIWUHEauBv5qT4Av2tWasiTY1Jw6puUNqRJXQg=="
     },
     "number-is-nan": {
       "version": "1.0.1",

--- a/package.json
+++ b/package.json
@@ -1,12 +1,40 @@
 {
-  "name": "tutorial",
-  "version": "0.5.0",
+  "name": "ex-tutorial-nodejs",
+  "version": "0.6.0",
+  "description": "An interactive tutorial to get started with the Node.js bindings for DAML",
+  "main": "index.js",
   "dependencies": {
-    "@digitalasset/daml-ledger": "0.5.0",
+    "@digitalasset/daml-ledger": "0.6.0",
     "uuid": "3.3.2"
   },
   "scripts": {
     "start": "node ./index.js",
     "fetch-template-ids": "rm -f ./template-ids.json && node ./util/fetch-template-ids.js -o ./template-ids.json"
-  }
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/digital-asset/ex-tutorial-nodejs.git"
+  },
+  "keywords": [
+    "smart",
+    "contracts",
+    "distributed",
+    "ledger",
+    "technologies",
+    "dlt",
+    "blockchain"
+  ],
+  "author": {
+    "name": "Digital Asset (Switzerland) GmbH and/or its affiliates",
+    "email": "support@digitalasset.com",
+    "url": "https://www.digitalasset.com"
+  },
+  "contributors": [
+    "Stefano Baghino <stefano.baghino@digitalasset.com>"
+  ],
+  "license": "Apache-2.0",
+  "bugs": {
+    "url": "https://github.com/digital-asset/ex-tutorial-nodejs/issues"
+  },
+  "homepage": "https://github.com/digital-asset/ex-tutorial-nodejs#readme"
 }

--- a/util/fetch-template-ids.js
+++ b/util/fetch-template-ids.js
@@ -29,7 +29,7 @@ daml.DamlLedgerClient.connect({ host: host, port: port }, (error, client) => {
                     const moduleName = damlModule.getName().getSegmentsList().join('.');
                     for (const template of damlModule.getTemplatesList()) {
                         const templateName = template.getTycon().getSegmentsList().join('.');
-                        const name = `${moduleName}.${templateName}`;
+                        const name = `${moduleName}:${templateName}`;
                         writer.write(`${first ? '' : ','}"${name}":${JSON.stringify({
                             packageId: packageId,
                             moduleName: moduleName,
@@ -45,7 +45,7 @@ daml.DamlLedgerClient.connect({ host: host, port: port }, (error, client) => {
 
 function printUsageAndExit() {
     console.log('Usage: [-h/--host LEDGER_HOST] [-p/--port LEDGER_PORT] [-o/--out OUT_FILE]');
-    console.log('Defaults to [host: localhost, port: 7600, out: stdout]');
+    console.log('Defaults to [host: localhost, port: 6865, out: stdout]');
     process.exit(-1);
 }
 
@@ -75,5 +75,5 @@ function readOptions() {
             printUsageAndExit();
         }
     }
-    return [host || 'localhost', port || 7600, out];
+    return [host || 'localhost', port || 6865, out];
 }


### PR DESCRIPTION
- use the latest and greatest bindings
  - showcase the usage of helpers to express DAML values more concisely†
- use the latest and greatest SDK
  - replace usages of the `da` SDK assistant with `daml`
  - switch the default port to 6865 (instead of 7600)
- improve the package manifest and make it more complete
- fix layout errors in the `README.md`
- remove references to older APIs
- fix error with transactions and explain the rationale

† unfortunately in this example this doesn't yield much savings, but it's still worth to show it, I believe