### PR TITLE
Upgrade to bindings 0.6.1 and SDK 0.12.21

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ To set it up, clone the repo, making sure to checkout the tag corresponding to t
 
     git clone git@github.com:digital-asset/ex-tutorial-nodejs.git
     cd ex-tutorial-nodejs
-    git checkout v0.6.0
+    git checkout v0.6.1
 
 The repo includes `daml/PingPong.daml`, which is the source for a DAML module with two templates: `Ping` and `Pong`. The app uses these.
 

--- a/daml.yaml
+++ b/daml.yaml
@@ -1,4 +1,4 @@
-sdk-version: 0.12.20
+sdk-version: 0.12.21
 name: ex-tutorial-nodejs
 source: daml/PingPong.daml
 parties:
@@ -6,7 +6,7 @@ parties:
 - Bob
 exposed-modules:
 - PingPong
-version: '0.6.0'
+version: '0.6.1'
 dependencies:
 - daml-prim
 - daml-stdlib

--- a/package-lock.json
+++ b/package-lock.json
@@ -5,9 +5,9 @@
   "requires": true,
   "dependencies": {
     "@digitalasset/daml-ledger": {
-      "version": "0.6.0",
-      "resolved": "https://registry.npmjs.org/@digitalasset/daml-ledger/-/daml-ledger-0.6.0.tgz",
-      "integrity": "sha512-o/kMewdBeCKM5zU8+EiECwP7/2OE7uATceH3UwI4S+I6HhTKK1CEtnNYgPpepYmqvO51ZJkcPDR/zhjregg+qA==",
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/@digitalasset/daml-ledger/-/daml-ledger-0.6.1.tgz",
+      "integrity": "sha512-8W/nnDKYApWaP0HdZVDzWsUKy33hLw1j1DmyeMDgIbM/DTO9XYzMdM7E6EbemNUGMCnsZgI4qXDcJ1MiQGPHMA==",
       "requires": {
         "google-protobuf": "3.7.1",
         "grpc": "1.18.0"

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "An interactive tutorial to get started with the Node.js bindings for DAML",
   "main": "index.js",
   "dependencies": {
-    "@digitalasset/daml-ledger": "0.6.0",
+    "@digitalasset/daml-ledger": "0.6.1",
     "uuid": "3.3.2"
   },
   "scripts": {


### PR DESCRIPTION
No improvements made to the tutorials, just switched to 0.6.1 (which solves https://github.com/digital-asset/daml-js/issues/68) and the latest publicly-available SDK version.

If you want to test the tutorial, please be advised that the `v0.6.1` tag does not exist yet as it will be created as a result of merging this PR. You are advised to test from `HEAD`.